### PR TITLE
Preloading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "core-js": "^3.34.0",
         "howler": "^2.2.4",
         "roboto-fontface": "*",
+        "thenby": "^1.3.4",
         "vue": "^3.4.21",
         "vue-toast-notification": "^3.1.2",
         "vuetify": "^3.5.8"
@@ -4383,6 +4384,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/thenby": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
+      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "core-js": "^3.34.0",
     "howler": "^2.2.4",
     "roboto-fontface": "*",
+    "thenby": "^1.3.4",
     "vue": "^3.4.21",
     "vue-toast-notification": "^3.1.2",
     "vuetify": "^3.5.8"

--- a/src/components/SpotifyTrack.vue
+++ b/src/components/SpotifyTrack.vue
@@ -6,7 +6,7 @@
           <DivOverlay :show="noPreview">
             <v-img :src="artworkSrc" aspect-ratio="1" />
             <template #overlay>
-              <span class="no-preview">No Preview</span>
+              <v-icon size="x-large">mdi-music-off</v-icon>
             </template>
           </DivOverlay>
           <div class="pl-4">
@@ -22,7 +22,7 @@
         <DivOverlay :show="noPreview">
           <v-img :src="artworkSrc" aspect-ratio="1" />
           <template #overlay>
-            <span class="no-preview">No Preview</span>
+            <v-icon size="x-large">mdi-music-off</v-icon>
           </template>
         </DivOverlay>
         <div class="mt-2">

--- a/src/components/SpotifyTrack.vue
+++ b/src/components/SpotifyTrack.vue
@@ -5,7 +5,9 @@
         <div class="top">
           <DivOverlay :show="noPreview">
             <v-img :src="artworkSrc" aspect-ratio="1" />
-            <template #overlay> <span class="no-preview">No Preview</span> </template>
+            <template #overlay>
+              <span class="no-preview">No Preview</span>
+            </template>
           </DivOverlay>
           <div class="pl-4">
             <div class="text-h6">{{ trackName }}</div>
@@ -19,7 +21,9 @@
       <template v-else>
         <DivOverlay :show="noPreview">
           <v-img :src="artworkSrc" aspect-ratio="1" />
-          <template #overlay> <span class="no-preview">No Preview</span> </template>
+          <template #overlay>
+            <span class="no-preview">No Preview</span>
+          </template>
         </DivOverlay>
         <div class="mt-2">
           <div class="text-h6">{{ trackName }}</div>

--- a/src/composables/audio.ts
+++ b/src/composables/audio.ts
@@ -40,7 +40,6 @@ export class PreloadedAudio {
   public state = readonly(this.internalState);
 
   constructor(src: string, opts?: AudioOptions) {
-    this.internalState.value = 'loading';
     this._src = src;
     this._name = opts?.name;
 
@@ -50,7 +49,7 @@ export class PreloadedAudio {
       format: 'mp3',
       loop: false,
       autoplay: false,
-      preload: true,
+      preload: false,
       html5: true,
       onload: () => (this.internalState.value = 'loaded'),
       onplay: () => {
@@ -107,6 +106,11 @@ export class PreloadedAudio {
     this.prom = DeferredPromise();
   }
 
+  load() {
+    this.sound.load();
+    (this.internalState as any) = 'loading';
+  }
+
   unload() {
     (this.internalState as any) = 'unloaded';
     this.sound.unload();
@@ -158,20 +162,33 @@ class PreloadedAudioManager {
   stop() {
     this.current?.stop();
     this.current = undefined;
+    return this;
   }
 
   reload(src: string) {
     const audio = this.lookup.value[src];
     if (!audio) {
-      return;
+      return this;
     }
 
     audio.reload();
+    return this;
+  }
+
+  load(src: string) {
+    const audio = this.lookup.value[src];
+    if (!audio) {
+      return;
+    }
+
+    audio.load();
+    return this;
   }
 
   unload() {
     this.stop();
     Object.values(this.lookup.value).forEach(a => a.unload());
+    return this;
   }
 }
 

--- a/src/features/shrinker/Shrinker.vue
+++ b/src/features/shrinker/Shrinker.vue
@@ -24,7 +24,7 @@
       v-else-if="stage === 'results'"
       :kept="results.map(r => r.kept).flat()"
       :removed="results.map(r => r.removed).flat()"
-      @reset="onReset()"
+      @reset="goToConfig()"
       @keep-going="goToConfig"
     />
   </div>
@@ -36,7 +36,6 @@ import ShrinkerConfig from './ShrinkerConfig.vue';
 import ShrinkerPlay from './ShrinkerPlay.vue';
 import ShrinkerResults from './ShrinkerResults.vue';
 import { useShrinker } from './useShrinker';
-import { AudioManager } from '@/composables/audio';
 
 const {
   stage,

--- a/src/features/shrinker/ShrinkerPlay.vue
+++ b/src/features/shrinker/ShrinkerPlay.vue
@@ -56,7 +56,7 @@
             :artwork-src="track.imageSrc"
             :artist="track.artist"
             :horizontal="!horizontal"
-            :loading="!!track.previewUrl && !loadedTrackSrcs.includes(track.previewUrl)"
+            :loading="track.loading.value"
             :no-preview="!track.previewUrl"
           >
             <div class="d-flex">
@@ -101,7 +101,6 @@ import { Track } from '@/types/spotify.types';
 import StartOverlay from '@/components/StartOverlay.vue';
 import { useModalController } from '@/modals';
 import MusicLoadingModal from '@/modals/MusicLoadingModal.vue';
-import { AudioManager } from '@/composables/audio';
 
 const props = defineProps<{
   isStarted: boolean;
@@ -125,10 +124,6 @@ const { width, height } = useWindowSize();
 const horizontal = computed(() => width.value > height.value);
 
 const aspectRatio = computed(() => (horizontal.value ? '0.75' : '3'));
-
-const loadedTrackSrcs = computed(() => {
-  return AudioManager.records.value.filter(r => r.state === 'loaded').map(r => r.src);
-});
 
 const onSelect = (index: number) => {
   const kept: Track[] = [];

--- a/src/features/shrinker/ShrinkerPlay.vue
+++ b/src/features/shrinker/ShrinkerPlay.vue
@@ -146,8 +146,10 @@ const onSelect = (index: number) => {
 };
 
 const onShowLoading = async () => {
+  const highlightSrcs = props.round.tracks.map(t => t.previewUrl).filter(p => !!p) as string[];
   await modalController.show({
     component: MusicLoadingModal,
+    props: { highlightSrcs },
     options: { maxWidth: '80vw' },
   });
 };

--- a/src/features/shrinker/ShrinkerResults.vue
+++ b/src/features/shrinker/ShrinkerResults.vue
@@ -31,38 +31,38 @@
       <v-card class="px-10 py-6" max-width="600px">
         <h2 class="text-center mb-6">Whats next?</h2>
         <div class="options-layout text-center">
-          <div>
+          <div v-if="kept.length">
             <h3>Kept</h3>
             <v-btn
+              v-if="kept.length >= 4"
               color="primary"
               variant="elevated"
-              :disabled="props.kept.length < 4"
-              @click="onKeepGoing(props.kept)"
+              @click="onKeepGoing(kept)"
             >
               Keep Cutting
             </v-btn>
-            <v-btn color="secondary" @click="onSavePlaylist(props.kept)">Save Playlist</v-btn>
+            <v-btn color="secondary" @click="onSavePlaylist(kept)"> Save Playlist </v-btn>
           </div>
-          <div>
+          <div v-if="removed.length">
             <h3>Removed</h3>
             <v-btn
+              v-if="removed.length >= 4"
               color="primary"
               variant="elevated"
-              :disabled="props.kept.length < 4"
-              @click="onKeepGoing(props.removed)"
+              @click="onKeepGoing(removed)"
             >
               Keep Cutting
             </v-btn>
-            <v-btn color="secondary" @click="onSavePlaylist(props.removed)">Save Playlist</v-btn>
+            <v-btn color="secondary" @click="onSavePlaylist(removed)"> Save Playlist </v-btn>
           </div>
         </div>
 
         <v-btn class="mt-10 w-100" color="primary" variant="elevated" @click="emits('reset')">
           Again!
         </v-btn>
-        <v-btn class="mt-3 w-100" color="error" variant="elevated" :to="{ name: 'home' }"
-          >Home</v-btn
-        >
+        <v-btn class="mt-3 w-100" color="error" variant="elevated" :to="{ name: 'home' }">
+          Home
+        </v-btn>
       </v-card>
     </CenteredDiv>
   </div>

--- a/src/modals/MusicLoadingModal.vue
+++ b/src/modals/MusicLoadingModal.vue
@@ -35,6 +35,7 @@ import { AudioManager } from '@/composables/audio';
 import type { AudioState } from '@/composables/audio';
 import ModalLayout from './ModalLayout.vue';
 import { computed } from 'vue';
+import { firstBy } from 'thenby';
 
 const ICONS: Record<AudioState, { icon: string; color?: string }> = {
   unloaded: { icon: 'mdi-crosshairs-question' },
@@ -43,12 +44,12 @@ const ICONS: Record<AudioState, { icon: string; color?: string }> = {
   errored: { icon: 'mdi-alert-circle-outline', color: 'red' },
 };
 
-defineProps<{
+const props = defineProps<{
   highlightSrcs?: string[];
 }>();
 
 const items = computed(() => {
-  return AudioManager.records.value.map(r => {
+  const items = AudioManager.records.value.map(r => {
     const icon = ICONS[r.state];
 
     return {
@@ -59,6 +60,10 @@ const items = computed(() => {
       error: r.error,
     };
   });
+
+  const highlightSrcs = props.highlightSrcs || [];
+  items.sort(firstBy(x => highlightSrcs.includes(x.src), 'desc'));
+  return items;
 });
 
 const onReload = (src: string) => {

--- a/src/modals/MusicLoadingModal.vue
+++ b/src/modals/MusicLoadingModal.vue
@@ -1,7 +1,11 @@
 <template>
   <ModalLayout title="Music Pre-loader">
     <v-list lines="three">
-      <v-list-item v-for="(item, index) of items" :key="index">
+      <v-list-item
+        v-for="(item, index) of items"
+        :key="index"
+        :active="highlightSrcs?.includes(item.src)"
+      >
         <template #prepend>
           <v-progress-circular v-if="item.icon.icon === 'loading'" class="loading" indeterminate />
           <v-icon v-else class="pl-7" :icon="item.icon.icon" :color="item.icon.color" />
@@ -38,6 +42,10 @@ const ICONS: Record<AudioState, { icon: string; color?: string }> = {
   loaded: { icon: 'mdi-check', color: 'green' },
   errored: { icon: 'mdi-alert-circle-outline', color: 'red' },
 };
+
+defineProps<{
+  highlightSrcs?: string[];
+}>();
 
 const items = computed(() => {
   return AudioManager.records.value.map(r => {


### PR DESCRIPTION
- replaced "no preview" with icon to fit on smaller screens
- removed auto-preloading to now only preload the next tracks
- no longer unload everything to make replays faster
- hide result options that are not helpful
- added highlight and sorting for music modal